### PR TITLE
Implement And Operator

### DIFF
--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj
@@ -214,6 +214,7 @@
     <ClInclude Include="..\antlr4-runtime\Vocabulary.h" />
     <ClInclude Include="..\antlr4-runtime\WritableToken.h" />
     <ClInclude Include="..\BuiltinFunctions\Add.h" />
+    <ClInclude Include="..\BuiltinFunctions\And.h" />
     <ClInclude Include="..\BuiltinFunctions\Subtract.h" />
     <ClInclude Include="..\Code\pch.h" />
     <ClInclude Include="..\Parser\Constant.h" />
@@ -228,10 +229,12 @@
     <ClInclude Include="..\Parser\ExpressionType.h" />
     <ClInclude Include="..\Parser\FunctionTable.h" />
     <ClInclude Include="..\Parser\FunctionUtils.h" />
+    <ClInclude Include="..\Parser\Options.h" />
     <ClInclude Include="..\Parser\ReturnType.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\BuiltinFunctions\Add.cpp" />
+    <ClCompile Include="..\BuiltinFunctions\And.cpp" />
     <ClCompile Include="..\BuiltinFunctions\Subtract.cpp" />
     <ClCompile Include="..\Code\pch.cpp" />
     <ClCompile Include="..\Parser\Constant.cpp" />

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj.filters
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj.filters
@@ -207,6 +207,12 @@
     <ClInclude Include="..\BuiltinFunctions\Subtract.h">
       <Filter>BuiltinFunctions</Filter>
     </ClInclude>
+    <ClInclude Include="..\BuiltinFunctions\And.h">
+      <Filter>BuiltinFunctions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Parser\Options.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Code\pch.cpp">
@@ -255,6 +261,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\BuiltinFunctions\Subtract.cpp">
+      <Filter>BuiltinFunctions</Filter>
+    </ClCompile>
+    <ClCompile Include="..\BuiltinFunctions\And.cpp">
       <Filter>BuiltinFunctions</Filter>
     </ClCompile>
   </ItemGroup>

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Add.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Add.cpp
@@ -11,8 +11,6 @@ AdaptiveExpressions_BuiltinFunctions::Add::Add() :
 {
 }
 
-
-
 ValueErrorTuple AdaptiveExpressions_BuiltinFunctions::Add::EvaluateOperator(std::vector<std::any> args)
 {
     std::any result;

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/And.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/And.cpp
@@ -1,0 +1,55 @@
+#include "And.h"
+#include "../Parser/ExpressionType.h"
+#include "../Parser/FunctionUtils.h"
+
+#include <limits>
+#include <any>
+#include <cstdlib>
+
+AdaptiveExpressions_BuiltinFunctions::And::And() :
+    ExpressionEvaluator(ExpressionType::And, (ReturnType)((int)ReturnType::String | (int)ReturnType::Number))
+{
+}
+
+ValueErrorTuple AdaptiveExpressions_BuiltinFunctions::And::TryEvaluate(Expression* expression, void* state, Options* options)
+{
+    std::any result = true;
+    std::string error;
+
+    // Create a childEvaluateOptions using the locale from the passed in parameter but with NullSubstitution unset
+    Options childEvaluateOptions;
+    childEvaluateOptions.locale = options ? options->locale : "";
+
+    for (int i = 0; i < expression->getChildrenCount(); ++i)
+    {
+        Expression* child = expression->getChildAt(i);
+
+        ValueErrorTuple childResult = child->TryEvaluate(state, &childEvaluateOptions);
+        if (childResult.second.empty())
+        {
+            if (FunctionUtils::isLogicTrue(childResult.first))
+            {
+                result = true;
+            }
+            else
+            {
+                result = false;
+                break;
+            }
+        }
+        else
+        {
+            // We interpret any error as false and swallow the error
+            result = false;
+            error = nullptr;
+            break;
+        }
+    }
+
+    return ValueErrorTuple(result, error);
+}
+
+void AdaptiveExpressions_BuiltinFunctions::And::ValidateExpression(Expression* expression)
+{
+    FunctionUtils::ValidateArityAndAnyType(expression, 1, INT_MAX);
+}

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/And.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/And.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "../Parser/ExpressionEvaluatorWithArgs.h"
+
+namespace AdaptiveExpressions_BuiltinFunctions
+{
+    class And : public ExpressionEvaluator
+    {
+    public:
+        And();
+        void ValidateExpression(Expression* expression);
+        virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) override;
+    };
+}

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Code/pch.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Code/pch.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <algorithm>
 #include "../Parser/ReturnType.h"
+#include "../Parser/Options.h"
 
 class Expression;
 class Constant;
@@ -25,7 +26,7 @@ typedef std::pair<std::string, std::string> (*EvaluateExpressionFunction)(Expres
 typedef void (*EvaluateExpressionValidatorFunction)(Expression*);
 
 typedef std::pair<std::any, std::string> ValueErrorTuple;
-typedef std::function<ValueErrorTuple (Expression*, void*, void*)> EvaluateExpressionLambda;
+typedef std::function<ValueErrorTuple (Expression*, void*, Options*)> EvaluateExpressionLambda;
 
 #include "../Parser/Expression.h"
 #include "../Parser/ExpressionEvaluator.h"

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Constant.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Constant.cpp
@@ -42,7 +42,7 @@ ConstantExpressionEvaluator::ConstantExpressionEvaluator() :
 {
 }
 
-ValueErrorTuple ConstantExpressionEvaluator::TryEvaluate(Expression* expression, void* state, void* options)
+ValueErrorTuple ConstantExpressionEvaluator::TryEvaluate(Expression* expression, void* state, Options* options)
 {
     Constant* constant = (Constant*)expression;
     return ValueErrorTuple(constant->getValue(), std::string());

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Constant.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Constant.h
@@ -24,6 +24,6 @@ class ConstantExpressionEvaluator : public ExpressionEvaluator
 public:
     ConstantExpressionEvaluator();
 
-    virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, void* options) override;
+    virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) override;
     virtual void ValidateExpression(Expression* expression) override;
 };

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Expression.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Expression.cpp
@@ -128,7 +128,7 @@ Expression* Expression::getChildren()
 }
 */
 
-ValueErrorTuple Expression::TryEvaluate(void* state, void* options)
+ValueErrorTuple Expression::TryEvaluate(void* state, Options* options)
 {
     return m_evaluator->TryEvaluate(this, state, options);
 }

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Expression.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Expression.h
@@ -5,6 +5,7 @@
 #include <string>
 #include "ExpressionParser.h"
 #include "FunctionTable.h"
+#include "Options.h"
 
 class Expression
 {
@@ -25,7 +26,7 @@ public:
     void Validate();
     ExpressionEvaluator* getEvaluator();
 
-    ValueErrorTuple TryEvaluate(void* state, void* options = nullptr);
+    ValueErrorTuple TryEvaluate(void* state, Options* options = nullptr);
 
     static const FunctionTable* Functions;
 

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionEvaluator.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionEvaluator.h
@@ -4,6 +4,7 @@
 
 #include "Expression.h"
 #include "ReturnType.h"
+#include "Options.h"
 
 class Expression;
 
@@ -14,7 +15,7 @@ public:
         std::string type,
         ReturnType returnType = ReturnType::Object);
 
-    virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, void* options) = 0;
+    virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) = 0;
     virtual void ValidateExpression(Expression* expression) = 0;
 
     void setReturnType(ReturnType returnType);

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionEvaluatorWithArgs.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionEvaluatorWithArgs.cpp
@@ -4,13 +4,13 @@
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    ValueErrorTuple ExpressionEvaluatorWithArgs::TryEvaluate(Expression* expression, void* state, void* options)
+    ValueErrorTuple ExpressionEvaluatorWithArgs::TryEvaluate(Expression* expression, void* state, Options* options)
     {
         return ApplyWithError(expression, state, options);
     }
 
 
-    ValueErrorTuple ExpressionEvaluatorWithArgs::ApplyWithError(Expression* expression, void* state, void* options)
+    ValueErrorTuple ExpressionEvaluatorWithArgs::ApplyWithError(Expression* expression, void* state, Options* options)
     {
         std::any value;
         std::string error;

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionEvaluatorWithArgs.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionEvaluatorWithArgs.h
@@ -8,11 +8,11 @@ namespace AdaptiveExpressions_BuiltinFunctions
     public:
         ExpressionEvaluatorWithArgs(std::string type, ReturnType returnType) : ExpressionEvaluator(type, returnType) {}
 
-        virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, void* options) override;
+        virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) override;
 
     protected:
 
-        ValueErrorTuple ApplyWithError(Expression* expression, void* state, void* options);
+        ValueErrorTuple ApplyWithError(Expression* expression, void* state, Options* options);
         ValueErrorTuple ApplySequenceWithError(std::vector<std::any> args, void* verify);
         virtual ValueErrorTuple EvaluateOperator(std::vector<std::any> args) = 0;
 

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionParser.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionParser.cpp
@@ -95,12 +95,14 @@ antlrcpp::Any ExpressionParser::ExpressionTransformer::visitFuncInvokeExp(Expres
     ExpressionAntlrParser::ArgsListContext* argContext = context->argsList();
     std::vector<antlr4::tree::ParseTree*> argChildren = argContext->children;
 
+    // TODO - in the C# version this part happens in a ProcessArgsList function that also checks for LambdaContexts
     std::vector<Expression*> childExpressions;
     for (auto argChild : argChildren)
     {
         // TODO - in the C# version this part happens in a ProcessArgsList function that also checks for LambdaContexts
         if (dynamic_cast<ExpressionAntlrParser::ExpressionContext*>(argChild))
         {
+            std::string text = argChild->getText();
             auto childExpression = visit(argChild);
             childExpressions.push_back(childExpression);
         }
@@ -115,9 +117,29 @@ antlrcpp::Any ExpressionParser::ExpressionTransformer::visitFuncInvokeExp(Expres
     return MakeExpression(functionName, childExpressions);
 }
 
-antlrcpp::Any ExpressionParser::ExpressionTransformer::visitIdAtom(ExpressionAntlrParser::IdAtomContext* ctx)
+antlrcpp::Any ExpressionParser::ExpressionTransformer::visitIdAtom(ExpressionAntlrParser::IdAtomContext* context)
 {
-    return antlrcpp::Any();
+    Expression* result;
+    auto symbol = context->getText();
+    //auto normalized = symbol->ToLowerInvariant(); //CPP_PORT_TODO - case insensitivity
+    if (symbol == "false")
+    {
+        result = Expression::ConstantExpression(false);
+    }
+    else if (symbol == "true")
+    {
+        result = Expression::ConstantExpression(true);
+    }
+    else if (symbol == "null")
+    {
+        result = Expression::ConstantExpression(nullptr);
+    }
+    else
+    {
+        //result = MakeExpression(ExpressionType::Accessor, Expression::ConstantExpression(symbol)); //CPP_PORT_TODO
+    }
+
+    return result;
 }
 
 antlrcpp::Any ExpressionParser::ExpressionTransformer::visitIndexAccessExp(ExpressionAntlrParser::IndexAccessExpContext* ctx)

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionType.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionType.cpp
@@ -7,4 +7,8 @@
 const std::string ExpressionType::Add = "+";
 const std::string ExpressionType::Subtract = "-";
 
+const std::string ExpressionType::And = "&&";
+const std::string ExpressionType::Or = "||";
+const std::string ExpressionType::Not = "!";
+
 const std::string ExpressionType::Constant = "Constant";

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionType.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/ExpressionType.h
@@ -35,9 +35,9 @@ public:
     const std::string Exists = "exists";
 
     // Logic
-    const std::string And = "&&";
-    const std::string Or = "||";
-    const std::string Not = "!";
+    static const std::string And;
+    static const std::string Or;
+    static const std::string Not;
 
     // String
     const std::string Concat = "concat";

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/FunctionTable.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/FunctionTable.cpp
@@ -1,5 +1,6 @@
 #include "FunctionTable.h"
 #include "../BuiltinFunctions/Add.h"
+#include "../BuiltinFunctions/And.h"
 #include "../BuiltinFunctions/Subtract.h"
 
 FunctionTable::FunctionTable() : std::map<std::string, ExpressionEvaluator*>()
@@ -15,4 +16,7 @@ void FunctionTable::PopulateStandardFunctions()
 
     this->insert(std::pair<std::string, ExpressionEvaluator*>("subtract", new AdaptiveExpressions_BuiltinFunctions::Subtract()));
     this->insert(std::pair<std::string, ExpressionEvaluator*>("-", new AdaptiveExpressions_BuiltinFunctions::Subtract()));
+
+    this->insert(std::pair<std::string, ExpressionEvaluator*>("and", new AdaptiveExpressions_BuiltinFunctions::And()));
+    this->insert(std::pair<std::string, ExpressionEvaluator*>("&&", new AdaptiveExpressions_BuiltinFunctions::And()));
 }

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/FunctionUtils.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/FunctionUtils.cpp
@@ -52,7 +52,22 @@ bool FunctionUtils::isNumber(std::any value)
     return isInteger(value) || isFloat(value) || isDouble(value);
 }
 
-ValueErrorTuple FunctionUtils::EvaluateChildren(Expression* expression, void* state, void* options, void* verify)
+bool FunctionUtils::isLogicTrue(std::any value)
+{
+    bool result = true;
+    if (isOfType<bool>(value))
+    {
+        result = std::any_cast<bool>(value);;
+    }
+    else if (!value.has_value())
+    {
+        result = false;
+    }
+
+    return result;
+}
+
+ValueErrorTuple FunctionUtils::EvaluateChildren(Expression* expression, void* state, Options* options, void* verify)
 {
     std::vector<std::any> args;
     std::any value;
@@ -107,7 +122,7 @@ std::string FunctionUtils::VerifyNumberOrStringOrNull(std::any value, Expression
 
 EvaluateExpressionLambda FunctionUtils::ApplyWithError(std::function<ValueErrorTuple(std::vector<std::any>)> f, void* verify)
 {
-    return [&](Expression* expression, void* state, void* options)
+    return [&](Expression* expression, void* state, Options* options)
     {
         std::any value;
         std::string error;

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/FunctionUtils.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/FunctionUtils.h
@@ -39,8 +39,9 @@ public:
 
     static bool isInteger(std::any value);
     static bool isNumber(std::any value);
+    static bool isLogicTrue(std::any value);
 
-    static ValueErrorTuple EvaluateChildren(Expression* expression, void* state, void* options, void* verify = nullptr);
+    static ValueErrorTuple EvaluateChildren(Expression* expression, void* state, Options* options, void* verify = nullptr);
 
     static std::any ResolveValue(std::any value);
 

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Options.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Parser/Options.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "../Code/pch.h"
+
+/// <summary>
+/// Options used to define evaluation behaviors.
+/// </summary>
+struct Options
+{
+    // CPP_PORT_TODO - C# version defaults locale to Thread.CurrentThread.CurrentCulture.Name;
+    std::string locale;
+
+    // CPP_PORT_TODO - In C# this class includes a Null Substitution function:
+    // "function that been called when there is null value hit in memory."
+    // public Func<string, object> NullSubstitution { get; set; } = null;
+    void* nullSubstitution = nullptr;
+};

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/UnitTest1/OperatorTests.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/UnitTest1/OperatorTests.cpp
@@ -9,16 +9,19 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace OperatorTests
 {
-	TEST_CLASS(OperatorTests)
-	{
-	public:
+    TEST_CLASS(OperatorTests)
+    {
+    public:
 
+        ValueErrorTuple ParseAndEvaluate(std::string expression)
+        {
+            auto parsed = Expression::Parse(expression);
+            return parsed->TryEvaluate(nullptr);
+        }
 
         void MathTest(std::string expression, int expectedValue)
         {
-            auto parsed = Expression::Parse(expression);
-
-            ValueErrorTuple valueAndError = parsed->TryEvaluate(nullptr);
+            ValueErrorTuple valueAndError = ParseAndEvaluate(expression);
 
             bool cast{};
             Assert::AreEqual(expectedValue, FunctionUtils::castToType<int>(valueAndError.first, cast));
@@ -26,24 +29,52 @@ namespace OperatorTests
             std::cout << "Error " << valueAndError.second << std::endl;
         }
 
-        TEST_METHOD(AddOperatorTest)
-		{
-            MathTest("1 + 2", 3);
-		}
-
-        TEST_METHOD(AddFunctionTest)
+        void LogicTest(std::string expression, bool expectedValue)
         {
+            ValueErrorTuple valueAndError = ParseAndEvaluate(expression);
+
+            bool cast{};
+            Assert::AreEqual(expectedValue, FunctionUtils::castToType<bool>(valueAndError.first, cast));
+
+            std::cout << "Error " << valueAndError.second << std::endl;
+        }
+
+        TEST_METHOD(ConstantNumberTest)
+        {
+            MathTest("5", 5);
+        }
+
+        TEST_METHOD(AddTest)
+        {
+            MathTest("1 + 2", 3);
+            MathTest("1 + 2 + 3", 6);
+            MathTest("add(1, 2)", 3);
             MathTest("add(1, 2, 3)", 6);
         }
 
-        TEST_METHOD(SubtractOperatorTest)
+        TEST_METHOD(SubtractTest)
         {
             MathTest("5 - 3", 2);
+            MathTest("5 - 3 - 1", 1);
+            MathTest("subtract(20, 4)", 16);
+            MathTest("subtract(20, 4, 1)", 15);
         }
 
-        TEST_METHOD(SubtractFunctionTest)
+        TEST_METHOD(ConstantBooleanTest)
         {
-            MathTest("subtract(20, 4)", 16);
+            LogicTest("true", true);
+            LogicTest("false", false);
         }
-	};
+
+        TEST_METHOD(AndTest)
+        {
+            LogicTest("and(true, true)", true);
+            LogicTest("and(true, false)", false);
+            LogicTest("and(false, false)", false);
+
+            LogicTest("true && true)", true);
+            LogicTest("true && false)", false);
+            LogicTest("false && false)", false);
+        }
+    };
 }


### PR DESCRIPTION
## Description
Added support for the And operator

## Specific Changes
  - Added an And class to built in functions
  - Added a skeleton Options structure and updated functions using it to pass the class around. The C# version of the And code set particular properties on the options class so putting it in place allowed that code to be ported.
  - Ported implementation of ExpressionParser::ExpressionTransformer::visitIdAtom to support "true" and "false" values

## Testing
 - Added tests for constant booleans, constant numbers, and the and operator
 - Reorganization of tests to group cases of a particular operator together
 - Added more permutations to some existing tests 