### PR TITLE
Add Ceiling and Floor Operators

### DIFF
--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj
@@ -215,13 +215,15 @@
     <ClInclude Include="..\antlr4-runtime\WritableToken.h" />
     <ClInclude Include="..\BuiltinFunctions\Add.h" />
     <ClInclude Include="..\BuiltinFunctions\And.h" />
+    <ClInclude Include="..\BuiltinFunctions\Ceiling.h" />
+    <ClInclude Include="..\BuiltinFunctions\ExpressionEvaluatorForSequenceOperator.h" />
+    <ClInclude Include="..\BuiltinFunctions\Floor.h" />
     <ClInclude Include="..\BuiltinFunctions\Not.h" />
     <ClInclude Include="..\BuiltinFunctions\Or.h" />
     <ClInclude Include="..\BuiltinFunctions\Subtract.h" />
     <ClInclude Include="..\Code\Constant.h" />
     <ClInclude Include="..\Code\Expression.h" />
     <ClInclude Include="..\Code\ExpressionEvaluator.h" />
-    <ClInclude Include="..\Code\ExpressionEvaluatorWithArgs.h" />
     <ClInclude Include="..\Code\ExpressionFunctions.h" />
     <ClInclude Include="..\Code\ExpressionParser.h" />
     <ClInclude Include="..\Code\ExpressionType.h" />
@@ -238,13 +240,15 @@
   <ItemGroup>
     <ClCompile Include="..\BuiltinFunctions\Add.cpp" />
     <ClCompile Include="..\BuiltinFunctions\And.cpp" />
+    <ClCompile Include="..\BuiltinFunctions\Ceiling.cpp" />
+    <ClCompile Include="..\BuiltinFunctions\ExpressionEvaluatorForSequenceOperator.cpp" />
+    <ClCompile Include="..\BuiltinFunctions\Floor.cpp" />
     <ClCompile Include="..\BuiltinFunctions\Not.cpp" />
     <ClCompile Include="..\BuiltinFunctions\Or.cpp" />
     <ClCompile Include="..\BuiltinFunctions\Subtract.cpp" />
     <ClCompile Include="..\Code\Constant.cpp" />
     <ClCompile Include="..\Code\Expression.cpp" />
     <ClCompile Include="..\Code\ExpressionEvaluator.cpp" />
-    <ClCompile Include="..\Code\ExpressionEvaluatorWithArgs.cpp" />
     <ClCompile Include="..\Code\ExpressionFunctions.cpp" />
     <ClCompile Include="..\Code\ExpressionParser.cpp" />
     <ClCompile Include="..\Code\ExpressionType.cpp" />

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj.filters
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp.vcxproj.filters
@@ -192,9 +192,6 @@
     <ClInclude Include="..\Code\ExpressionEvaluator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\Code\ExpressionEvaluatorWithArgs.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\Code\ExpressionFunctions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -220,6 +217,15 @@
       <Filter>BuiltinFunctions</Filter>
     </ClInclude>
     <ClInclude Include="..\BuiltinFunctions\Not.h">
+      <Filter>BuiltinFunctions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\BuiltinFunctions\Ceiling.h">
+      <Filter>BuiltinFunctions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\BuiltinFunctions\ExpressionEvaluatorForSequenceOperator.h">
+      <Filter>BuiltinFunctions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\BuiltinFunctions\Floor.h">
       <Filter>BuiltinFunctions</Filter>
     </ClInclude>
   </ItemGroup>
@@ -257,9 +263,6 @@
     <ClCompile Include="..\Code\ExpressionEvaluator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\Code\ExpressionEvaluatorWithArgs.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\Code\ExpressionFunctions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -279,6 +282,15 @@
       <Filter>BuiltinFunctions</Filter>
     </ClCompile>
     <ClCompile Include="..\BuiltinFunctions\Not.cpp">
+      <Filter>BuiltinFunctions</Filter>
+    </ClCompile>
+    <ClCompile Include="..\BuiltinFunctions\Ceiling.cpp">
+      <Filter>BuiltinFunctions</Filter>
+    </ClCompile>
+    <ClCompile Include="..\BuiltinFunctions\ExpressionEvaluatorForSequenceOperator.cpp">
+      <Filter>BuiltinFunctions</Filter>
+    </ClCompile>
+    <ClCompile Include="..\BuiltinFunctions\Floor.cpp">
       <Filter>BuiltinFunctions</Filter>
     </ClCompile>
   </ItemGroup>

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Add.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Add.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>
 
 AdaptiveExpressions_BuiltinFunctions::Add::Add() : 
-    ExpressionEvaluatorWithArgs(ExpressionType::Add, (ReturnType)((int)ReturnType::String | (int)ReturnType::Number))
+    ExpressionEvaluatorForSequenceOperator(ExpressionType::Add, (ReturnType)((int)ReturnType::String | (int)ReturnType::Number))
 {
 }
 

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Add.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Add.h
@@ -1,9 +1,9 @@
 #pragma once
-#include "../Code/ExpressionEvaluatorWithArgs.h"
+#include "ExpressionEvaluatorForSequenceOperator.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    class Add : public ExpressionEvaluatorWithArgs
+    class Add : public ExpressionEvaluatorForSequenceOperator
     {
     public:
         Add();

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/And.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/And.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../Code/ExpressionEvaluatorWithArgs.h"
+#include "../Code/ExpressionEvaluator.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Ceiling.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Ceiling.cpp
@@ -1,0 +1,33 @@
+#include "Ceiling.h"
+#include "../Code/ExpressionType.h"
+#include "../Code/FunctionUtils.h"
+
+#include <limits>
+#include <any>
+#include <cstdlib>
+#include <cmath>
+#include <math.h>
+
+AdaptiveExpressions_BuiltinFunctions::Ceiling::Ceiling() :
+    ExpressionEvaluator(ExpressionType::Ceiling, ReturnType::Number)
+{
+}
+
+ValueErrorTuple AdaptiveExpressions_BuiltinFunctions::Ceiling::TryEvaluate(Expression* expression, void* state, Options* options)
+{
+    std::any result;
+
+    ValueErrorTuple childResult = expression->getChildAt(0)->TryEvaluate(state, options);
+    if (childResult.second.empty())
+    {
+        bool castSuccess;
+        result = ceil(FunctionUtils::castToType<double>(childResult.first, castSuccess));
+    }
+
+    return ValueErrorTuple(result, childResult.second);
+}
+
+void AdaptiveExpressions_BuiltinFunctions::Ceiling::ValidateExpression(Expression* expression)
+{
+    FunctionUtils::ValidateArityAndAnyType(expression, 1, 1, ReturnType::Number);
+}

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Ceiling.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Ceiling.h
@@ -1,13 +1,14 @@
 #pragma once
-#include "../Code/ExpressionEvaluator.h"
+#include "..\Code\ExpressionEvaluator.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    class Not : public ExpressionEvaluator
+    class Ceiling : public ExpressionEvaluator
     {
     public:
-        Not();
+        Ceiling();
         void ValidateExpression(Expression* expression);
         virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) override;
+
     };
 }

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/ExpressionEvaluatorForSequenceOperator.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/ExpressionEvaluatorForSequenceOperator.cpp
@@ -1,16 +1,16 @@
 #pragma once
-#include "../Code/ExpressionEvaluatorWithArgs.h"
+#include "ExpressionEvaluatorForSequenceOperator.h"
 #include "../Code/FunctionUtils.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    ValueErrorTuple ExpressionEvaluatorWithArgs::TryEvaluate(Expression* expression, void* state, Options* options)
+    ValueErrorTuple ExpressionEvaluatorForSequenceOperator::TryEvaluate(Expression* expression, void* state, Options* options)
     {
         return ApplyWithError(expression, state, options);
     }
 
 
-    ValueErrorTuple ExpressionEvaluatorWithArgs::ApplyWithError(Expression* expression, void* state, Options* options)
+    ValueErrorTuple ExpressionEvaluatorForSequenceOperator::ApplyWithError(Expression* expression, void* state, Options* options)
     {
         std::any value;
         std::string error;
@@ -38,7 +38,7 @@ namespace AdaptiveExpressions_BuiltinFunctions
         return ValueErrorTuple(value, error);
     }
 
-    ValueErrorTuple ExpressionEvaluatorWithArgs::ApplySequenceWithError(std::vector<std::any> args, void* verify)
+    ValueErrorTuple ExpressionEvaluatorForSequenceOperator::ApplySequenceWithError(std::vector<std::any> args, void* verify)
     {
         std::vector<std::any> binaryArgs(2);
         std::any sofar = args[0];

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/ExpressionEvaluatorForSequenceOperator.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/ExpressionEvaluatorForSequenceOperator.h
@@ -3,10 +3,10 @@
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    class ExpressionEvaluatorWithArgs : public ExpressionEvaluator
+    class ExpressionEvaluatorForSequenceOperator : public ExpressionEvaluator
     {
     public:
-        ExpressionEvaluatorWithArgs(std::string type, ReturnType returnType) : ExpressionEvaluator(type, returnType) {}
+        ExpressionEvaluatorForSequenceOperator(std::string type, ReturnType returnType) : ExpressionEvaluator(type, returnType) {}
 
         virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) override;
 

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Floor.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Floor.cpp
@@ -1,0 +1,33 @@
+#include "Floor.h"
+#include "../Code/ExpressionType.h"
+#include "../Code/FunctionUtils.h"
+
+#include <limits>
+#include <any>
+#include <cstdlib>
+#include <cmath>
+#include <math.h>
+
+AdaptiveExpressions_BuiltinFunctions::Floor::Floor() :
+    ExpressionEvaluator(ExpressionType::Floor, ReturnType::Number)
+{
+}
+
+ValueErrorTuple AdaptiveExpressions_BuiltinFunctions::Floor::TryEvaluate(Expression* expression, void* state, Options* options)
+{
+    std::any result;
+
+    ValueErrorTuple childResult = expression->getChildAt(0)->TryEvaluate(state, options);
+    if (childResult.second.empty())
+    {
+        bool castSuccess;
+        result = floor(FunctionUtils::castToType<double>(childResult.first, castSuccess));
+    }
+
+    return ValueErrorTuple(result, childResult.second);
+}
+
+void AdaptiveExpressions_BuiltinFunctions::Floor::ValidateExpression(Expression* expression)
+{
+    FunctionUtils::ValidateArityAndAnyType(expression, 1, 1, ReturnType::Number);
+}

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Floor.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Floor.h
@@ -1,13 +1,14 @@
 #pragma once
-#include "../Code/ExpressionEvaluator.h"
+#include "..\Code\ExpressionEvaluator.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    class Not : public ExpressionEvaluator
+    class Floor : public ExpressionEvaluator
     {
     public:
-        Not();
+        Floor();
         void ValidateExpression(Expression* expression);
         virtual ValueErrorTuple TryEvaluate(Expression* expression, void* state, Options* options) override;
+
     };
 }

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Or.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Or.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../Code/ExpressionEvaluatorWithArgs.h"
+#include "../Code/ExpressionEvaluator.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Subtract.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Subtract.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>
 
 AdaptiveExpressions_BuiltinFunctions::Subtract::Subtract() : 
-    ExpressionEvaluatorWithArgs(ExpressionType::Subtract, (ReturnType)((int)ReturnType::String | (int)ReturnType::Number))
+    ExpressionEvaluatorForSequenceOperator(ExpressionType::Subtract, (ReturnType)((int)ReturnType::String | (int)ReturnType::Number))
 {
 }
 

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Subtract.h
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/BuiltinFunctions/Subtract.h
@@ -1,9 +1,9 @@
 #pragma once
-#include "../Code/ExpressionEvaluatorWithArgs.h"
+#include "ExpressionEvaluatorForSequenceOperator.h"
 
 namespace AdaptiveExpressions_BuiltinFunctions
 {
-    class Subtract : public ExpressionEvaluatorWithArgs
+    class Subtract : public ExpressionEvaluatorForSequenceOperator
     {
     public:
         Subtract();

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Code/ExpressionParser.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Code/ExpressionParser.cpp
@@ -168,22 +168,6 @@ antlrcpp::Any ExpressionParser::ExpressionTransformer::visitNumericAtom(Expressi
 
     try
     {
-        int integer = std::stoi(numericString);
-        return Expression::ConstantExpression(integer);
-    }
-    catch (const std::bad_any_cast&)
-    {
-    }
-
-    try
-    {
-        long long int longInteger = std::stol(numericString);
-        return Expression::ConstantExpression(longInteger);
-    }
-    catch (const std::bad_any_cast&) {}
-
-    try
-    {
         double decimalValue = std::stod(numericString);
         return Expression::ConstantExpression(decimalValue);
     }

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Code/FunctionTable.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/Code/FunctionTable.cpp
@@ -4,6 +4,8 @@
 #include "../BuiltinFunctions/And.h"
 #include "../BuiltinFunctions/Or.h"
 #include "../BuiltinFunctions/Not.h"
+#include "../BuiltinFunctions/Ceiling.h"
+#include "../BuiltinFunctions/Floor.h"
 
 FunctionTable::FunctionTable() : std::map<std::string, ExpressionEvaluator*>()
 {
@@ -17,7 +19,9 @@ void FunctionTable::PopulateStandardFunctions()
     this->insert(std::pair<std::string, ExpressionEvaluator*>("+", new AdaptiveExpressions_BuiltinFunctions::Add()));
     this->insert(std::pair<std::string, ExpressionEvaluator*>("subtract", new AdaptiveExpressions_BuiltinFunctions::Subtract()));
     this->insert(std::pair<std::string, ExpressionEvaluator*>("-", new AdaptiveExpressions_BuiltinFunctions::Subtract()));
-
+    this->insert(std::pair<std::string, ExpressionEvaluator*>("Ceiling", new AdaptiveExpressions_BuiltinFunctions::Ceiling()));
+    this->insert(std::pair<std::string, ExpressionEvaluator*>("Floor", new AdaptiveExpressions_BuiltinFunctions::Floor()));
+    
     // Logic
     this->insert(std::pair<std::string, ExpressionEvaluator*>("and", new AdaptiveExpressions_BuiltinFunctions::And()));
     this->insert(std::pair<std::string, ExpressionEvaluator*>("&&", new AdaptiveExpressions_BuiltinFunctions::And()));

--- a/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/UnitTest1/OperatorTests.cpp
+++ b/libraries/AdaptiveExpressionsCpp/AdaptiveExpressionsCpp/UnitTest1/OperatorTests.cpp
@@ -19,12 +19,21 @@ namespace OperatorTests
             return parsed->TryEvaluate(nullptr);
         }
 
-        void MathTest(std::string expression, int expectedValue)
+        void MathTest(std::string expression, double expectedValue)
         {
             ValueErrorTuple valueAndError = ParseAndEvaluate(expression);
 
-            bool cast{};
-            Assert::AreEqual(expectedValue, FunctionUtils::castToType<int>(valueAndError.first, cast));
+            bool castSuccess{};
+            int intResult = FunctionUtils::castToType<int>(valueAndError.first, castSuccess);
+            if (castSuccess)
+            {
+                Assert::AreEqual(expectedValue, (double) intResult);
+            }
+            else
+            {
+                Assert::AreEqual(expectedValue, FunctionUtils::castToType<double>(valueAndError.first, castSuccess));
+
+            }
 
             std::cout << "Error " << valueAndError.second << std::endl;
         }
@@ -42,22 +51,37 @@ namespace OperatorTests
         TEST_METHOD(ConstantNumberTest)
         {
             MathTest("5", 5);
+            MathTest("5.3", 5.3);
         }
 
         TEST_METHOD(AddTest)
         {
             MathTest("1 + 2", 3);
             MathTest("1 + 2 + 3", 6);
+            MathTest("1.2 + 3.6", 4.8);
             MathTest("add(1, 2)", 3);
             MathTest("add(1, 2, 3)", 6);
+            MathTest("add(1.2, 3.6)", 4.8);
         }
 
         TEST_METHOD(SubtractTest)
         {
             MathTest("5 - 3", 2);
             MathTest("5 - 3 - 1", 1);
+            MathTest("5.5 - 3.2", 2.3);
             MathTest("subtract(20, 4)", 16);
             MathTest("subtract(20, 4, 1)", 15);
+            MathTest("subtract(5.5, 3.2", 2.3);
+        }
+
+        TEST_METHOD(CeilingTest)
+        {
+            MathTest("Ceiling(2.3)", 3);
+        }
+
+        TEST_METHOD(FloorTest)
+        {
+            MathTest("Floor(2.3)", 2);
         }
 
         TEST_METHOD(ConstantBooleanTest)


### PR DESCRIPTION
## Description
Add support for floor and ceiling operators

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added build in functions for `ceiling` and `floor`
  - Renamed ExpressionEvaluatorWIthArgs to ExpressionEvaluatorForSequenceOperator to make usage clearer (this behavior is based on the C# helper function ApplySequenceWithError)
  - Updated visitNumericAtom to convert to double using std::stod. Previously it was trying to use stoi which was truncating non-integer vaues.

## Testing
 - New tests for ceiling and floor
 - Updated Add, Subtract, and Constant Number tests to include tests for non-integer values.